### PR TITLE
Basic support for simple SCSI disk slot collection

### DIFF
--- a/lib/genesis_collector/disks.rb
+++ b/lib/genesis_collector/disks.rb
@@ -10,6 +10,7 @@ module GenesisCollector
         d[:product] = info.match(/^(?:Device Model|Product):\s+(.*)$/)[1]
         d[:serial_number] = info.match(/^Serial (?:n|N)umber:\s+(.*)$/)[1]
         d[:size] = info.match(/^User Capacity:\s+(.*)$/)[1].split('bytes')[0].strip.gsub(',', '')
+        d[:slot] = get_scsi_slot(d[:dev]) if d[:dev] =~ /^\/dev\/sd/
       end
     end
 
@@ -31,5 +32,9 @@ module GenesisCollector
       shellout_with_timeout("smartctl -i #{cmd_params}", 5)
     end
 
+    # FIXME - we might want to handle raid devices differently by parsing megacli
+    def get_scsi_slot(device)
+      File.basename(File.readlink("/sys/class/block/#{File.basename(device)}/device"))
+    end
   end
 end

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -312,6 +312,10 @@ RSpec.describe GenesisCollector::Collector do
       stub_shellout_with_timeout('smartctl -i /dev/bus/0 -d megaraid,0', 5, fixture('smartctl/megaraid0'))
       stub_shellout_with_timeout('smartctl -i /dev/bus/0 -d megaraid,1', 5, fixture('smartctl/megaraid0'))
       stub_shellout_with_timeout('smartctl -i /dev/bus/0 -d megaraid,2', 5, fixture('smartctl/megaraid0'))
+      stub_symlink_target('/sys/class/block/sda/device', '../../../5:0:0:0')
+      stub_symlink_target('/sys/class/block/sdb/device', '../../../4:0:0:0')
+      stub_symlink_target('/sys/class/block/sdc/device', '../../../3:0:0:0')
+      stub_symlink_target('/sys/class/block/sdd/device', '../../../2:0:0:0')
     end
     let(:payload) { collector.collect_disks; collector.payload }
     it 'should get disks' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,6 +102,11 @@ RSpec.configure do |config|
 =end
 end
 
+def stub_symlink_target(file, target)
+  stub_file_exists(file)
+  allow(File).to receive(:readlink).with(file).and_return(target)
+end
+
 def stub_file_content(file, content)
   stub_file_exists(file)
   allow(IO).to receive(:read).with(file).and_return(content)


### PR DESCRIPTION
@dwradcliffe for review

This will not work for most raid devices, unless the device is in JBOD mode.

For all other exposed SCSI devices though (90% of cases), this should give us the SCSI ID, which hopefully we can eventually map to the drive slot.