### PR TITLE
Bump HTTP timeout

### DIFF
--- a/lib/genesis_collector/simple_http.rb
+++ b/lib/genesis_collector/simple_http.rb
@@ -5,7 +5,7 @@ require 'genesis_collector'
 
 module GenesisCollector
   class SimpleHTTP
-    def initialize(host, headers: {}, timeout: 2)
+    def initialize(host, headers: {}, timeout: 10)
       @host = host
       @headers = {'User-Agent' => GenesisCollector::USER_AGENT}.merge! headers
       @timeout = timeout

--- a/lib/genesis_collector/version.rb
+++ b/lib/genesis_collector/version.rb
@@ -1,3 +1,3 @@
 module GenesisCollector
-  VERSION = '0.1.23'
+  VERSION = '0.1.24'
 end


### PR DESCRIPTION
2 seconds is not enough time for Genesis to handle the update request.

@dwradcliffe @dalehamel @ibawt 