### PR TITLE
collect fqdn

### DIFF
--- a/lib/genesis_collector/collector.rb
+++ b/lib/genesis_collector/collector.rb
@@ -55,6 +55,7 @@ module GenesisCollector
       @payload = {
         type: 'Server',
         hostname: get_hostname,
+        fqdn: get_fqdn,
         os: {
           distribution: get_distribution,
           release: get_release,
@@ -153,6 +154,10 @@ module GenesisCollector
 
     def get_hostname
       Socket.gethostname
+    end
+
+    def get_fqdn
+      Socket.gethostbyname(Socket.gethostname)[0]
     end
 
     def get_last_boot_time


### PR DESCRIPTION
We should collect the fqdn also, in case the hostname is the short name.

@andrewjamesbrown @dalehamel @dturn 