### PR TITLE
[bug fix] Match returns nil when no match happens

### DIFF
--- a/lib/genesis_collector/disks.rb
+++ b/lib/genesis_collector/disks.rb
@@ -42,7 +42,7 @@ module GenesisCollector
 
     def disk_uuid(drive)
       blk_id = blkid.detect { |s| s.include? drive }
-      /UUID="([^ ]*)"/.match(blk_id, 1)[1]
+      /UUID="([^ ]*)"/.match(blk_id, 1) { |m| m[1] }
     end
 
     def blkid


### PR DESCRIPTION
Use a block to handle nil case @Shopify/metalscale 