### PR TITLE
Expand available disk health statuses based on smartmontools

### DIFF
--- a/lib/genesis_collector/disks.rb
+++ b/lib/genesis_collector/disks.rb
@@ -28,29 +28,23 @@ module GenesisCollector
 
     private
 
-    DISK_STATUS = {
-      healthy: "healthy",
-      unhealthy: "unhealthy",
-      unknown: "unknown",
-      nil => "unknown"
-    }
     def disk_status(disk)
       output = shellout_with_timeout("smartctl -H #{disk}", 5)
 
       case output
       when /SMART overall-health self-assessment test result: FAILED/
-        DISK_STATUS[:unhealthy]
+        "unhealthy"
       when /SMART overall-health self-assessment test result: PASSED/
-        DISK_STATUS[:healthy]
+        "healthy"
       when /SMART overall-health self-assessment test result: UNKNOWN/
-        DISK_STATUS[:unknown]
+        "unknown"
       when /SMART Health Status: OK/
-        DISK_STATUS[:healthy]
+        "healthy"
       else
-        DISK_STATUS[:unhealthy]
+        "unhealthy"
       end
     rescue
-      DISK_STATUS[:healthy]
+      "healthy"
     end
 
     def enumerate_disks

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -456,8 +456,8 @@ RSpec.describe GenesisCollector::Collector do
       stub_shellout_with_timeout('smartctl -i /dev/bus/0 -d megaraid,2', 5, fixture('smartctl/megaraid0'))
       stub_shellout_with_timeout('smartctl -H /dev/sda', 5, fixture('smartctl/passed'), 0)
       stub_shellout_with_timeout('smartctl -H /dev/sdb', 5, fixture('smartctl/failed'), 1)
-      stub_shellout_with_timeout('smartctl -H /dev/sdc', 5, fixture('smartctl/passed'), 0)
-      stub_shellout_with_timeout('smartctl -H /dev/sdd', 5, fixture('smartctl/passed'), 0)
+      stub_shellout_with_timeout('smartctl -H /dev/sdc', 5, fixture('smartctl/unknown'), 0)
+      stub_shellout_with_timeout('smartctl -H /dev/sdd', 5, fixture('smartctl/ok'), 0)
       stub_shellout_with_timeout("blkid", 5, fixture('blkid'))
       stub_symlink_target('/sys/class/block/sda/device', '../../../5:0:0:0')
       stub_symlink_target('/sys/class/block/sdb/device', '../../../4:0:0:0')
@@ -525,8 +525,11 @@ RSpec.describe GenesisCollector::Collector do
       expect(payload[:disks][4][:uuid]).to be nil
     end
 
-    it 'should set unhealthy disks' do
+    it 'should set disk status' do
+      expect(payload[:disks][0][:status]).to eq('healthy')
       expect(payload[:disks][1][:status]).to eq('unhealthy')
+      expect(payload[:disks][2][:status]).to eq('unknown')
+      expect(payload[:disks][3][:status]).to eq('healthy')
     end
   end
 

--- a/spec/fixtures/smartctl/ok
+++ b/spec/fixtures/smartctl/ok
@@ -2,5 +2,4 @@ smartctl 6.2 2013-07-26 r3841 [x86_64-linux-3.19.0-68-generic] (local build)
 Copyright (C) 2002-13, Bruce Allen, Christian Franke, www.smartmontools.org
 
 === START OF READ SMART DATA SECTION ===
-SMART overall-health self-assessment test result: FAILED!
-Drive failure expected in less than 24 hours. SAVE ALL DATA.
+SMART Health Status: OK

--- a/spec/fixtures/smartctl/unknown
+++ b/spec/fixtures/smartctl/unknown
@@ -2,5 +2,6 @@ smartctl 6.2 2013-07-26 r3841 [x86_64-linux-3.19.0-68-generic] (local build)
 Copyright (C) 2002-13, Bruce Allen, Christian Franke, www.smartmontools.org
 
 === START OF READ SMART DATA SECTION ===
-SMART overall-health self-assessment test result: FAILED!
-Drive failure expected in less than 24 hours. SAVE ALL DATA.
+SMART overall-health self-assessment test result: UNKNOWN
+SMART Status, Attributes and Thresholds cannot be read.
+


### PR DESCRIPTION
I originally didn't want to parse the output, but this has proved to be less than ideal when dealing with MegaRAID controllers.

This expands the disk health status checks based on the output available from the source code of smartmontools 6.1 and updates the fixtures to have the correct number of newlines as well.

@dalehamel @dturn