### PR TITLE
Fix dmi reads on newer dmidecode

### DIFF
--- a/lib/genesis_collector/collector.rb
+++ b/lib/genesis_collector/collector.rb
@@ -195,7 +195,7 @@ module GenesisCollector
     end
 
     def read_dmi(key)
-      value = shellout_with_timeout("dmidecode -s #{key}").gsub(/^#.+$/, '').strip
+      value = shellout_with_timeout("dmidecode -s #{key}").gsub(/^#.+$/, '').gsub(/^Invalid entry length.*$/,'').strip
       value = '' if '0123456789' == value # sometimes the firmware is broken
       value.empty? ? nil : value
     end

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -55,10 +55,12 @@ RSpec.describe GenesisCollector::Collector do
       before do
         stub_dmi('baseboard-manufacturer', "# SMBIOS implementations newer than version 2.8 are not\n# fully supported by this version of dmidecode.\nSupermicro")
         stub_dmi('baseboard-serial-number', "# SMBIOS implementations newer than version 2.8 are not\n# fully supported by this version of dmidecode.\nHM15CS331193")
+        stub_dmi('system-manufacturer', "Supermicro\nInvalid entry length (16). Fixed up to 11.")
       end
       it 'should get real value' do
         expect(collector.send(:read_dmi, 'baseboard-manufacturer')).to eq('Supermicro')
         expect(collector.send(:read_dmi, 'baseboard-serial-number')).to eq('HM15CS331193')
+        expect(collector.send(:read_dmi, 'system-manufacturer')).to eq('Supermicro')
       end
     end
   end


### PR DESCRIPTION
# What

On ubuntu 16.04, a newer version of dmidecode has this bug: http://savannah.nongnu.org/patch/?8989

This causes extra text to be printed to stdout when it should probably go to stderr, which screws up our parsing for anything reading from dmidecode

# How

This issue is resolved by grepping out the undesired lines.

not sure if best to do in shell or in ruby, probably should do ruby so i can more easily include a test...

@dwradcliffe @dturn for review