### PR TITLE
Fallback to ipmicfg when ipmitool fails

### DIFF
--- a/lib/genesis_collector/ipmi.rb
+++ b/lib/genesis_collector/ipmi.rb
@@ -22,7 +22,11 @@ module GenesisCollector
     def read_ipmi_fru(key)
       @ipmi_fru_output ||= shellout_with_timeout('ipmitool fru')
       match = @ipmi_fru_output.match(/#{key}\s*:\s*(\S+)$/)
-      raise "IPMI fru output missing key: #{key}" if match.nil?
+      if match.nil?
+        @ipmi_fru_output = shellout_with_timeout('ipmicfg -fru list')
+        match = @ipmi_fru_output.match(/#{key}\s*:\s*(\S+)$/)
+        raise "IPMI fru output missing key: #{key}" if match.nil?
+      end
       match[1]
     end
 

--- a/lib/genesis_collector/ipmi.rb
+++ b/lib/genesis_collector/ipmi.rb
@@ -1,5 +1,6 @@
 module GenesisCollector
   module IPMI
+    IPMITOOL_TO_IPMICFG = { 'Board Serial' => 'Board Serial number \(BS\)' }
 
     def collect_ipmi
       @payload[:ipmi] = {
@@ -24,7 +25,7 @@ module GenesisCollector
       match = @ipmi_fru_output.match(/#{key}\s*:\s*(\S+)$/)
       if match.nil?
         @ipmi_fru_output = shellout_with_timeout('ipmicfg -fru list')
-        match = @ipmi_fru_output.match(/#{key}\s*:\s*(\S+)$/)
+        match = @ipmi_fru_output.match(/#{IPMITOOL_TO_IPMICFG.fetch(key, key)}\s*=\s*(\S+)$/)
         raise "IPMI fru output missing key: #{key}" if match.nil?
       end
       match[1]

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe GenesisCollector::Collector do
         stub_dmi('baseboard-serial-number', '')
         stub_dmi('chassis-serial-number', '')
         stub_shellout('ipmitool fru', fixture('ipmitool_fru_broken'))
+        stub_shellout('ipmicfg -fru list', fixture('ipmitool_fru_broken'))
       end
       it 'should get product name' do
         expect { collector.collect_basic_data }.to raise_error(RuntimeError, /IPMI fru output missing key: Product Part Number/)


### PR DESCRIPTION
On the SPM the ipmitool fru can be empty. When that happens we should try a fallback before raising an error. ipmicfg is the fallback.