### PR TITLE
Some servers report memory in GB, so don't assume MB

### DIFF
--- a/lib/genesis_collector/collector.rb
+++ b/lib/genesis_collector/collector.rb
@@ -106,7 +106,7 @@ module GenesisCollector
         else
           empty = m['size'] == 'No Module Installed'
           {
-            size: m['size'].to_i * 1000000,
+            size: m['size']['GB'] ? m['size'].to_i * 1000000000 : m['size'].to_i * 1000000,
             description: empty ? "Empty #{m['form_factor']}" : "#{m['form_factor']} #{m['type_detail']} #{m['speed']}",
             bank: m['bank_locator'],
             slot: m['locator'],

--- a/lib/genesis_collector/collector.rb
+++ b/lib/genesis_collector/collector.rb
@@ -106,7 +106,7 @@ module GenesisCollector
         else
           empty = m['size'] == 'No Module Installed'
           {
-            size: m['size']['GB'] ? m['size'].to_i * 1000000000 : m['size'].to_i * 1000000,
+            size: m['size']['GB'] ? m['size'].to_i * 1024000000 : m['size'].to_i * 1000000,
             description: empty ? "Empty #{m['form_factor']}" : "#{m['form_factor']} #{m['type_detail']} #{m['speed']}",
             bank: m['bank_locator'],
             slot: m['locator'],

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -596,7 +596,7 @@ RSpec.describe GenesisCollector::Collector do
     it 'should get size' do
       expect(payload[:memories][0][:size]).to eq(16384000000)
       expect(payload[:memories][1][:size]).to eq(0)
-      expect(payload[:memories][2][:size]).to eq(17000000000)
+      expect(payload[:memories][2][:size]).to eq(17408000000)
     end
     it 'should get bank' do
       expect(payload[:memories][0][:bank]).to eq('P0_Node0_Channel0_Dimm0')

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -596,6 +596,7 @@ RSpec.describe GenesisCollector::Collector do
     it 'should get size' do
       expect(payload[:memories][0][:size]).to eq(16384000000)
       expect(payload[:memories][1][:size]).to eq(0)
+      expect(payload[:memories][2][:size]).to eq(17000000000)
     end
     it 'should get bank' do
       expect(payload[:memories][0][:bank]).to eq('P0_Node0_Channel0_Dimm0')

--- a/spec/fixtures/dmidecode
+++ b/spec/fixtures/dmidecode
@@ -202,7 +202,7 @@ Memory Device
 	Error Information Handle: Not Provided
 	Total Width: 72 bits
 	Data Width: 64 bits
-	Size: 16384 MB
+	Size: 17 GB
 	Form Factor: DIMM
 	Set: None
 	Locator: P1-DIMMB1


### PR DESCRIPTION
New h5 node reports wrong about of memory. This is because demidecode reports memory in GB instead of MB. Handle this case so we get accurate reports