### PR TITLE
add BIOS and IPMI firmware version to node properties

### DIFF
--- a/lib/genesis_collector/collector.rb
+++ b/lib/genesis_collector/collector.rb
@@ -72,6 +72,8 @@ module GenesisCollector
           'BASEBOARD_SERIAL_NUMBER' => read_dmi('baseboard-serial-number'),
           'CHASSIS_VENDOR' => read_dmi('chassis-manufacturer'),
           'CHASSIS_SERIAL_NUMBER' => read_dmi('chassis-serial-number'),
+          'BIOS_VERSION' => read_dmi('bios-version'),
+          'IPMI_FIRMWARE_VERSION' => read_ipmi_fw('Firmware Revision'),
         }
       }
 

--- a/lib/genesis_collector/ipmi.rb
+++ b/lib/genesis_collector/ipmi.rb
@@ -26,5 +26,11 @@ module GenesisCollector
       match[1]
     end
 
+    def read_ipmi_fw(key)
+      @ipmi_fw_output ||= shellout_with_timeout('ipmitool mc info')
+      match = @ipmi_fw_output.match(/#{key}\s*:\s*(\S+)$/)
+      raise "IPMI FW output missing key: #{key}" if match.nil?
+      match[1]
+    end
   end
 end

--- a/lib/genesis_collector/version.rb
+++ b/lib/genesis_collector/version.rb
@@ -1,3 +1,3 @@
 module GenesisCollector
-  VERSION = '0.1.42'
+  VERSION = '0.1.43'
 end

--- a/spec/fixtures/ipmitool_mc_info
+++ b/spec/fixtures/ipmitool_mc_info
@@ -1,0 +1,24 @@
+Device ID                 : 42
+Device Revision           : 23
+Firmware Revision         : 1.23
+IPMI Version              : 2.0
+Manufacturer ID           : 12345
+Manufacturer Name         : ACME Inc.
+Product ID                : 256 (0x0100)
+Product Name              : Unknown (0x100)
+Device Available          : yes
+Provides Device SDRs      : yes
+Additional Device Support :
+    Sensor Device
+    SDR Repository Device
+    SEL Device
+    FRU Inventory Device
+    IPMB Event Receiver
+    Bridge
+    Chassis Device
+    Nucular Carburator
+Aux Firmware Rev Info     : 
+    0x00
+    0x32
+    0x1e
+    0x1e


### PR DESCRIPTION
Collects IPMI/iDRAC and BIOS versions for Genesis as well.

MegaRaid FW / Device info also needs to be collected, PR for that should follow tomorrow.

Relates to https://github.com/Shopify/datastores/issues/1987