### PR TITLE
Add MegaRAID support

### DIFF
--- a/lib/genesis_collector/collector.rb
+++ b/lib/genesis_collector/collector.rb
@@ -7,6 +7,7 @@ require 'genesis_collector/chef'
 require 'genesis_collector/ipmi'
 require 'genesis_collector/disks'
 require 'genesis_collector/dmidecode'
+require 'genesis_collector/megaraid'
 require 'English'
 
 module GenesisCollector
@@ -18,6 +19,7 @@ module GenesisCollector
     include GenesisCollector::IPMI
     include GenesisCollector::Disks
     include GenesisCollector::DmiDecode
+    include GenesisCollector::MegaRaid
 
     def initialize(config = {})
       @chef_node = config.delete(:chef_node)
@@ -34,6 +36,7 @@ module GenesisCollector
       safely { collect_disks }
       safely { collect_cpus }
       safely { collect_memories }
+      safely { collect_raids }
       @payload
     end
 
@@ -118,6 +121,10 @@ module GenesisCollector
           }
         end
       end.compact
+    end
+
+    def collect_raids
+      collect_megaraid if megaraid?
     end
 
     private

--- a/lib/genesis_collector/megaraid.rb
+++ b/lib/genesis_collector/megaraid.rb
@@ -1,0 +1,52 @@
+module GenesisCollector
+  module MegaRaid
+
+    def collect_megaraid
+      @payload[:raids] ||= []
+      @payload[:properties] ||= {}
+      if megaraid?
+        @payload[:properties]['MEGARAID_TYPE'] = read_megacli_adapter_type
+        @payload[:properties]['MEGARAID_FW_PACKAGE'] = read_megacli_adapter_firmware
+        @payload[:raids].concat read_megacli_logical_disks
+      end
+    end
+
+    def megaraid?
+      return !read_megacli_adapter_type.nil?
+    end
+
+    private
+
+    def megacli_adapter_output()
+      @megacli_adapter_output ||= shellout_with_timeout('megacli -AdpAllInfo -aAll', 10)
+    end
+
+    def read_megacli_adapter_type()
+      match = megacli_adapter_output.match(/Product Name\s*:\s*(.+)\s*$/)
+      return nil if match.nil?
+      match[1]
+    end
+
+    def read_megacli_adapter_firmware()
+      match = megacli_adapter_output.match(/FW Package Build\s*:\s*(\S+)$/)
+      return nil if match.nil?
+      match[1]
+    end
+
+    def read_megacli_logical_disks()
+      @megacli_ld_output ||= shellout_with_timeout('megacli -LDInfo -Lall -aAll', 10)
+      lds = []
+      @megacli_ld_output.split(/^$/).each do |disk|
+        lines = disk.split(/\n+/)
+        next if lines.count < 5 # skip status and empty
+        record = {}
+        lines.each do |line|
+          match = line.match(/\s*(.+?)\s*:\s*(.+)\s*$/)
+          record[match[1]] = match[2] unless match.nil?
+        end
+        lds << record
+      end
+      lds
+    end
+  end
+end

--- a/lib/genesis_collector/version.rb
+++ b/lib/genesis_collector/version.rb
@@ -1,3 +1,3 @@
 module GenesisCollector
-  VERSION = '0.1.45'
+  VERSION = '0.1.46'
 end

--- a/spec/fixtures/megacli_AdpAllInfo
+++ b/spec/fixtures/megacli_AdpAllInfo
@@ -1,0 +1,301 @@
+                                     
+Adapter #0
+
+==============================================================================
+                    Versions
+                ================
+Product Name    : PERC H710P Adapter
+Serial No       : 48M00DK
+FW Package Build: 21.3.2-0005
+
+                    Mfg. Data
+                ================
+Mfg. Date       : 08/24/14
+Rework Date     : 08/24/14
+Revision No     : A06
+Battery FRU     : N/A
+
+                Image Versions in Flash:
+                ================
+BIOS Version       : 5.42.00.1_4.12.05.00_0x05290003
+Ctrl-R Version     : 4.04-0003
+Preboot CLI Version: 05.00-03:#%00008
+FW Version         : 3.131.05-4520
+NVDATA Version     : 2.1108.03-0096
+Boot Block Version : 2.03.00.00-0004
+BOOT Version       : 06.253.57.219
+
+                Pending Images in Flash
+                ================
+None
+
+                PCI Info
+                ================
+Controller Id	: 0000
+Vendor Id       : 1000
+Device Id       : 005b
+SubVendorId     : 1028
+SubDeviceId     : 1f31
+
+Host Interface  : PCIE
+
+ChipRevision    : D1
+
+Link Speed 	     : 2 
+Number of Frontend Port: 0 
+Device Interface  : PCIE
+
+Number of Backend Port: 8 
+Port  :  Address
+0        500056b37789abff 
+1        0000000000000000 
+2        0000000000000000 
+3        0000000000000000 
+4        0000000000000000 
+5        0000000000000000 
+6        0000000000000000 
+7        0000000000000000 
+
+                HW Configuration
+                ================
+SAS Address      : 5b083fe0c863aa00
+BBU              : Present
+Alarm            : Absent
+NVRAM            : Present
+Serial Debugger  : Present
+Memory           : Present
+Flash            : Present
+Memory Size      : 1024MB
+TPM              : Absent
+On board Expander: Absent
+Upgrade Key      : Absent
+Temperature sensor for ROC    : Present
+Temperature sensor for controller    : Present
+
+ROC temperature : 73  degree Celsius
+Controller temperature : 73  degree Celcius
+
+                Settings
+                ================
+Current Time                     : 10:26:27 4/21, 2017
+Predictive Fail Poll Interval    : 300sec
+Interrupt Throttle Active Count  : 16
+Interrupt Throttle Completion    : 50us
+Rebuild Rate                     : 30%
+PR Rate                          : 30%
+BGI Rate                         : 30%
+Check Consistency Rate           : 30%
+Reconstruction Rate              : 30%
+Cache Flush Interval             : 4s
+Max Drives to Spinup at One Time : 4
+Delay Among Spinup Groups        : 12s
+Physical Drive Coercion Mode     : 128MB
+Cluster Mode                     : Disabled
+Alarm                            : Disabled
+Auto Rebuild                     : Enabled
+Battery Warning                  : Enabled
+Ecc Bucket Size                  : 255
+Ecc Bucket Leak Rate             : 240 Minutes
+Restore HotSpare on Insertion    : Disabled
+Expose Enclosure Devices         : Disabled
+Maintain PD Fail History         : Disabled
+Host Request Reordering          : Enabled
+Auto Detect BackPlane Enabled    : SGPIO/i2c SEP
+Load Balance Mode                : Auto
+Use FDE Only                     : Yes
+Security Key Assigned            : No
+Security Key Failed              : No
+Security Key Not Backedup        : No
+Default LD PowerSave Policy      : Controller Defined
+Maximum number of direct attached drives to spin up in 1 min : 20 
+Auto Enhanced Import             : No
+Any Offline VD Cache Preserved   : No
+Allow Boot with Preserved Cache  : No
+Disable Online Controller Reset  : No
+PFK in NVRAM                     : No
+Use disk activity for locate     : No
+POST delay			 : 90 seconds
+BIOS Error Handling          	 : Stop On Errors
+Current Boot Mode 		  :Normal
+                Capabilities
+                ================
+RAID Level Supported             : RAID0, RAID1, RAID5, RAID6, RAID00, RAID10, RAID50, RAID60, PRL 11, PRL 11 with spanning, PRL11-RLQ0 DDF layout with no span, PRL11-RLQ0 DDF layout with span
+Supported Drives                 : SAS, SATA
+
+Allowed Mixing:
+
+Mix in Enclosure Allowed
+
+                Status
+                ================
+ECC Bucket Count                 : 0
+
+                Limitations
+                ================
+Max Arms Per VD          : 32 
+Max Spans Per VD         : 8 
+Max Arrays               : 128 
+Max Number of VDs        : 64 
+Max Parallel Commands    : 1008 
+Max SGE Count            : 60 
+Max Data Transfer Size   : 8192 sectors 
+Max Strips PerIO         : 42 
+Max LD per array         : 16 
+Min Strip Size           : 64 KB
+Max Strip Size           : 1.0 MB
+Max Configurable CacheCade Size: 512 GB
+Current Size of CacheCade      : 0 GB
+Current Size of FW Cache       : 883 MB
+
+                Device Present
+                ================
+Virtual Drives    : 1 
+  Degraded        : 0 
+  Offline         : 0 
+Physical Devices  : 16 
+  Disks           : 14 
+  Critical Disks  : 0 
+  Failed Disks    : 0 
+
+                Supported Adapter Operations
+                ================
+Rebuild Rate                    : Yes
+CC Rate                         : Yes
+BGI Rate                        : Yes
+Reconstruct Rate                : Yes
+Patrol Read Rate                : Yes
+Alarm Control                   : Yes
+Cluster Support                 : No
+BBU                             : No
+Spanning                        : Yes
+Dedicated Hot Spare             : Yes
+Revertible Hot Spares           : Yes
+Foreign Config Import           : Yes
+Self Diagnostic                 : Yes
+Allow Mixed Redundancy on Array : No
+Global Hot Spares               : Yes
+Deny SCSI Passthrough           : No
+Deny SMP Passthrough            : No
+Deny STP Passthrough            : No
+Support Security                : Yes
+Snapshot Enabled                : No
+Support the OCE without adding drives : Yes
+Support PFK                     : No
+Support PI                      : No
+Support Boot Time PFK Change    : No
+Disable Online PFK Change       : No
+Support Shield State            : No
+Block SSD Write Disk Cache Change: No
+
+                Supported VD Operations
+                ================
+Read Policy          : Yes
+Write Policy         : Yes
+IO Policy            : Yes
+Access Policy        : Yes
+Disk Cache Policy    : Yes
+Reconstruction       : Yes
+Deny Locate          : No
+Deny CC              : No
+Allow Ctrl Encryption: No
+Enable LDBBM         : Yes
+Support Breakmirror  : Yes
+Power Savings        : Yes
+
+                Supported PD Operations
+                ================
+Force Online                            : Yes
+Force Offline                           : Yes
+Force Rebuild                           : Yes
+Deny Force Failed                       : No
+Deny Force Good/Bad                     : No
+Deny Missing Replace                    : No
+Deny Clear                              : No
+Deny Locate                             : No
+Support Temperature                     : Yes
+NCQ                                     : No
+Disable Copyback                        : No
+Enable JBOD                             : No
+Enable Copyback on SMART                : No
+Enable Copyback to SSD on SMART Error   : No
+Enable SSD Patrol Read                  : No
+PR Correct Unconfigured Areas           : Yes
+Enable Spin Down of UnConfigured Drives : No
+Disable Spin Down of hot spares         : Yes
+Spin Down time                          : 30 
+T10 Power State                         : Yes
+                Error Counters
+                ================
+Memory Correctable Errors   : 0 
+Memory Uncorrectable Errors : 0 
+
+                Cluster Information
+                ================
+Cluster Permitted     : No
+Cluster Active        : No
+
+                Default Settings
+                ================
+Phy Polarity                     : 0 
+Phy PolaritySplit                : 0 
+Background Rate                  : 30 
+Strip Size                       : 64kB
+Flush Time                       : 4 seconds
+Write Policy                     : WB
+Read Policy                      : Adaptive
+Cache When BBU Bad               : Disabled
+Cached IO                        : No
+SMART Mode                       : Mode 6
+Alarm Disable                    : No
+Coercion Mode                    : 128MB
+ZCR Config                       : Unknown
+Dirty LED Shows Drive Activity   : No
+BIOS Continue on Error           : 0 
+Spin Down Mode                   : None
+Allowed Device Type              : SAS/SATA Mix
+Allow Mix in Enclosure           : Yes
+Allow HDD SAS/SATA Mix in VD     : No
+Allow SSD SAS/SATA Mix in VD     : No
+Allow HDD/SSD Mix in VD          : No
+Allow SATA in Cluster            : No
+Max Chained Enclosures           : 4 
+Disable Ctrl-R                   : No
+Enable Web BIOS                  : No
+Direct PD Mapping                : Yes
+BIOS Enumerate VDs               : Yes
+Restore Hot Spare on Insertion   : No
+Expose Enclosure Devices         : No
+Maintain PD Fail History         : No
+Disable Puncturing               : No
+Zero Based Enclosure Enumeration : Yes
+PreBoot CLI Enabled              : No
+LED Show Drive Activity          : Yes
+Cluster Disable                  : Yes
+SAS Disable                      : No
+Auto Detect BackPlane Enable     : SGPIO/i2c SEP
+Use FDE Only                     : Yes
+Enable Led Header                : No
+Delay during POST                : 0 
+EnableCrashDump                  : No
+Disable Online Controller Reset  : No
+EnableLDBBM                      : Yes
+Un-Certified Hard Disk Drives    : Allow
+Treat Single span R1E as R10     : Yes
+Max LD per array                 : 16
+Power Saving option              : Don't spin down unconfigured drives
+Don't spin down Hot spares
+Don't Auto spin down Configured Drives
+Power settings apply to all drives - individual PD/LD power settings cannot be set
+Max power savings option is  not allowed for LDs. Only T10 power conditions are to be used.
+Cached writes are not used for spun down VDs
+Can schedule disable power savings at controller level
+Default spin down time in minutes: 30 
+Enable JBOD                      : No
+TTY Log In Flash                 : Yes
+Auto Enhanced Import             : No
+BreakMirror RAID Support         : Yes
+Disable Join Mirror              : Yes
+Enable Shield State              : No
+Time taken to detect CME         : 60s
+
+Exit Code: 0x00

--- a/spec/fixtures/megacli_LDInfo
+++ b/spec/fixtures/megacli_LDInfo
@@ -1,0 +1,55 @@
+                                     
+
+Adapter 0 -- Virtual Drive Information:
+Virtual Drive: 0 (Target Id: 0)
+Name                :OS
+RAID Level          : Primary-1, Secondary-0, RAID Level Qualifier-0
+Size                : 893.75 GB
+Sector Size         : 512
+Mirror Data         : 893.75 GB
+State               : Optimal
+Strip Size          : 64 KB
+Number Of Drives    : 2
+Span Depth          : 1
+Default Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
+Current Cache Policy: WriteBack, ReadAheadNone, Direct, No Write Cache if Bad BBU
+Default Access Policy: Read/Write
+Current Access Policy: Read/Write
+Disk Cache Policy   : Disk's Default
+Encryption Type     : None
+Default Power Savings Policy: Controller Defined
+Current Power Savings Policy: None
+Can spin up in 1 minute: No
+LD has drives that support T10 power conditions: No
+LD's IO profile supports MAX power savings with cached writes: No
+Bad Blocks Exist: No
+Is VD Cached: No
+
+
+Virtual Drive: 1 (Target Id: 1)
+Name                :Virtual Disk 1
+RAID Level          : Primary-1, Secondary-3, RAID Level Qualifier-0
+Size                : 4.363 TB
+Sector Size         : 512
+Mirror Data         : 4.363 TB
+State               : Optimal
+Strip Size          : 64 KB
+Number Of Drives per span:2
+Span Depth          : 5
+Default Cache Policy: WriteThrough, ReadAheadNone, Direct, No Write Cache if Bad BBU
+Current Cache Policy: WriteThrough, ReadAheadNone, Direct, No Write Cache if Bad BBU
+Default Access Policy: Read/Write
+Current Access Policy: Read/Write
+Disk Cache Policy   : Enabled
+Encryption Type     : None
+Default Power Savings Policy: Controller Defined
+Current Power Savings Policy: None
+Can spin up in 1 minute: No
+LD has drives that support T10 power conditions: No
+LD's IO profile supports MAX power savings with cached writes: No
+Bad Blocks Exist: No
+Is VD Cached: No
+
+
+
+Exit Code: 0x00


### PR DESCRIPTION
Add MegaRaid support for https://github.com/Shopify/datastores/issues/1987

MEGARAID_TYPE and MEGARAID_FW_PACKAGE in the Genesis properties now can show Firmware version in place.

Additional :raids substructure shows all information about logical devices but need display support by Genesis.